### PR TITLE
Modificar la lógica que desencadena el cambio de estado de una solicitud

### DIFF
--- a/src/controllers/advisor-request.controller.ts
+++ b/src/controllers/advisor-request.controller.ts
@@ -16,7 +16,7 @@ import {
 } from '@loopback/rest';
 import {Response} from 'express-serve-static-core';
 import {SecurityConfiguration} from '../config/security.config';
-import {Request as RequestModel} from '../models';
+import {Report, Request as RequestModel} from '../models';
 import {AdvisorRepository} from '../repositories';
 import {AdvisorRequestService} from '../services/advisor-request.service';
 import {FileManagerService} from '../services/fileManager.service';
@@ -108,16 +108,28 @@ export class AdvisorRequestController {
       },
     },
   )
-  async patch(
+  async changeRequestState(
     @param.path.number('advisorId') advisorId: number,
     @param.path.number('requestId') requestId: number,
     @param.path.number('statusId') statusId: number,
+    @requestBody({
+      content: {
+        'application/json': {
+          schema: getModelSchemaRef(Report, {
+            title: 'Change request status',
+            exclude: ['id'],
+          }),
+        },
+      },
+    })
+    commentary?: Report,
   ): Promise<RequestModel> {
     try {
       const request = await this.advisorRequestService.changeRequestSatus(
         advisorId,
         requestId,
         statusId,
+        commentary,
       );
       if (!request) {
         throw new HttpErrors[400]('No se ha hecho la actualización');

--- a/src/controllers/advisor-request.controller.ts
+++ b/src/controllers/advisor-request.controller.ts
@@ -122,14 +122,14 @@ export class AdvisorRequestController {
         },
       },
     })
-    commentary?: Report,
+    report?: Report,
   ): Promise<RequestModel> {
     try {
       const request = await this.advisorRequestService.changeRequestSatus(
         advisorId,
         requestId,
         statusId,
-        commentary,
+        report,
       );
       if (!request) {
         throw new HttpErrors[400]('No se ha hecho la actualización');

--- a/src/services/advisor-request.service.ts
+++ b/src/services/advisor-request.service.ts
@@ -37,7 +37,7 @@ export class AdvisorRequestService {
     advisorId: number,
     requestId: number,
     newStatusId: number,
-    commentary: Report | undefined,
+    report: Report | undefined,
   ): Promise<RequestModel | null> {
     const oldRequest = await this.requestRepository.findOne({
       where: {id: requestId, advisorId: advisorId},
@@ -207,7 +207,7 @@ export class AdvisorRequestService {
       );
 
       if (newStatusId == 4) {
-        if (!commentary) {
+        if (!report) {
           throw new HttpErrors[400](
             'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
           );
@@ -220,7 +220,7 @@ export class AdvisorRequestService {
           filter,
         );
 
-        this.requestRepository.reports(oldRequest.id).create(commentary);
+        this.requestRepository.reports(oldRequest.id).create(report);
 
         const propertyRequests = property.requests;
         const customers = await this.getRejectedCustomers(
@@ -234,7 +234,7 @@ export class AdvisorRequestService {
       }
 
       if (newStatusId == 5) {
-        if (!commentary) {
+        if (!report) {
           throw new HttpErrors[400](
             'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
           );
@@ -247,7 +247,7 @@ export class AdvisorRequestService {
           filter,
         );
 
-        this.requestRepository.reports(oldRequest.id).create(commentary);
+        this.requestRepository.reports(oldRequest.id).create(report);
 
         const propertyRequests = property.requests;
         const customers = await this.getRejectedCustomers(
@@ -267,18 +267,20 @@ export class AdvisorRequestService {
       }
 
       if (newStatusId == 12) {
-        if (!commentary) {
+        if (!report) {
           throw new HttpErrors[400](
             'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
           );
         }
         contentEmail = `${contentEmail} Su solicitud ha sido rechazada\n
-        Comentarios del asesor: ${commentary.commentary}`;
+        Comentarios del asesor: ${report.commentary}`;
+
+        this.requestRepository.reports(oldRequest.id).create(report);
       }
     }
 
     if (newStatusId == 8 || newStatusId == 9) {
-      if (!commentary) {
+      if (!report) {
         throw new HttpErrors[400](
           'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
         );
@@ -286,13 +288,13 @@ export class AdvisorRequestService {
 
       if (newStatusId == 8) {
         contentEmail = `${contentEmail} Su solicitud ha sido abortada ya que usted se lo ha solicitado al asesor.\n
-        Comentarios del asesor: ${commentary.commentary}`;
+        Comentarios del asesor: ${report.commentary}`;
       } else if (newStatusId == 9) {
         contentEmail = `${contentEmail} Su solicitud ha sido rechazada\n
-        Comentarios del asesor: ${commentary.commentary}`;
+        Comentarios del asesor: ${report.commentary}`;
       }
 
-      this.requestRepository.reports(oldRequest.id).create(commentary);
+      this.requestRepository.reports(oldRequest.id).create(report);
     }
 
     oldRequest.requestStatusId = newStatusId;

--- a/src/services/advisor-request.service.ts
+++ b/src/services/advisor-request.service.ts
@@ -267,7 +267,13 @@ export class AdvisorRequestService {
       }
 
       if (newStatusId == 12) {
-        contentEmail = `${contentEmail} Su solicitud ha sido rechazada`;
+        if (!commentary) {
+          throw new HttpErrors[400](
+            'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
+          );
+        }
+        contentEmail = `${contentEmail} Su solicitud ha sido rechazada\n
+        Comentarios del asesor: ${commentary.commentary}`;
       }
     }
 

--- a/src/services/advisor-request.service.ts
+++ b/src/services/advisor-request.service.ts
@@ -6,7 +6,7 @@ import {Request, Response} from 'express-serve-static-core';
 import path from 'path';
 import {generalConfiguration} from '../config/general.config';
 import {configurationNotification} from '../config/notification.config';
-import {Customer, Request as RequestModel} from '../models';
+import {Customer, Report, Request as RequestModel} from '../models';
 import {
   CustomerRepository,
   PropertyRepository,
@@ -37,6 +37,7 @@ export class AdvisorRequestService {
     advisorId: number,
     requestId: number,
     newStatusId: number,
+    commentary: Report | undefined,
   ): Promise<RequestModel | null> {
     const oldRequest = await this.requestRepository.findOne({
       where: {id: requestId, advisorId: advisorId},
@@ -130,6 +131,7 @@ export class AdvisorRequestService {
         `No puede cambiar el estado de una solicitud que ha sido abortada por un cliente`,
       );
     }
+
     if (oldRequest.requestStatusId == 10) {
       throw new HttpErrors[400](
         `No puede cambiar el estado de una solicitud que ha sido incumplimiento de contrato por parte de Akin`,
@@ -178,6 +180,7 @@ export class AdvisorRequestService {
       );
     }
 
+    ////////////////////////////////////////
     let contentEmail = '';
 
     if (
@@ -204,13 +207,20 @@ export class AdvisorRequestService {
       );
 
       if (newStatusId == 4) {
-        contentEmail = `${contentEmail} Felicitaciones, su solicitud ha sido aceptada`;
+        if (!commentary) {
+          throw new HttpErrors[400](
+            'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
+          );
+        }
+        contentEmail = `${contentEmail} Felicitaciones, su solicitud ha sido aceptada. Puede revisar los comentarios en la solicitud hechos por el asesor dirigiendose al sistema.`;
         const filter: Where<RequestModel> = {id: {neq: oldRequest.id}};
-        this.changeAllRequestsStatesThroughOneProperty(
+        await this.changeAllRequestsStatesThroughOneProperty(
           12,
           property.id!,
           filter,
         );
+
+        this.requestRepository.reports(oldRequest.id).create(commentary);
 
         const propertyRequests = property.requests;
         const customers = await this.getRejectedCustomers(
@@ -224,13 +234,20 @@ export class AdvisorRequestService {
       }
 
       if (newStatusId == 5) {
-        contentEmail = `${contentEmail} Felicitaciones, su solicitud ha sido aceptada`;
+        if (!commentary) {
+          throw new HttpErrors[400](
+            'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
+          );
+        }
+        contentEmail = `${contentEmail} Felicitaciones, su solicitud ha sido aceptada. Puede revisar los comentarios en la solicitud hechos por el asesor dirigiendose al sistema.`;
         const filter: Where<RequestModel> = {id: {neq: oldRequest.id}};
         this.changeAllRequestsStatesThroughOneProperty(
           12,
           property.id!,
           filter,
         );
+
+        this.requestRepository.reports(oldRequest.id).create(commentary);
 
         const propertyRequests = property.requests;
         const customers = await this.getRejectedCustomers(
@@ -248,18 +265,34 @@ export class AdvisorRequestService {
         por favor ingrese a akinmueble.com, inicie sesión, descargue el contrato
          y diligencielo correctamente para finalizar el proceso. Cualquier duda contacte con su asesor`;
       }
+
       if (newStatusId == 12) {
         contentEmail = `${contentEmail} Su solicitud ha sido rechazada`;
       }
+    }
+
+    if (newStatusId == 8 || newStatusId == 9) {
+      if (!commentary) {
+        throw new HttpErrors[400](
+          'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
+        );
+      }
+
+      if (newStatusId == 8) {
+        contentEmail = `${contentEmail} Su solicitud ha sido abortada ya que usted se lo ha solicitado al asesor.\n
+        Comentarios del asesor: ${commentary.commentary}`;
+      } else if (newStatusId == 9) {
+        contentEmail = `${contentEmail} Su solicitud ha sido rechazada\n
+        Comentarios del asesor: ${commentary.commentary}`;
+      }
+
+      this.requestRepository.reports(oldRequest.id).create(commentary);
     }
 
     oldRequest.requestStatusId = newStatusId;
 
     await this.requestRepository.update(oldRequest);
 
-    //TODO
-    //Acá es donde deberiamos notificar
-    //verificar si hay algo para notificar
     await this.notifyOneCustomer(customer, contentEmail);
 
     return await this.requestRepository.findById(requestId);

--- a/src/services/advisor-request.service.ts
+++ b/src/services/advisor-request.service.ts
@@ -209,7 +209,7 @@ export class AdvisorRequestService {
       if (newStatusId == 4) {
         if (!report) {
           throw new HttpErrors[400](
-            'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
+            'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarlo en los reportes',
           );
         }
         contentEmail = `${contentEmail} Felicitaciones, su solicitud ha sido aceptada. Puede revisar los comentarios en la solicitud hechos por el asesor dirigiendose al sistema.`;
@@ -236,7 +236,7 @@ export class AdvisorRequestService {
       if (newStatusId == 5) {
         if (!report) {
           throw new HttpErrors[400](
-            'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
+            'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarlo en los reportes',
           );
         }
         contentEmail = `${contentEmail} Felicitaciones, su solicitud ha sido aceptada. Puede revisar los comentarios en la solicitud hechos por el asesor dirigiendose al sistema.`;
@@ -269,7 +269,7 @@ export class AdvisorRequestService {
       if (newStatusId == 12) {
         if (!report) {
           throw new HttpErrors[400](
-            'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
+            'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarlo en los reportes',
           );
         }
         contentEmail = `${contentEmail} Su solicitud ha sido rechazada\n
@@ -282,7 +282,7 @@ export class AdvisorRequestService {
     if (newStatusId == 8 || newStatusId == 9) {
       if (!report) {
         throw new HttpErrors[400](
-          'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarolo en los reportes',
+          'Es necesario que hagas un comentario acerca del cambio del estado de la solicitud para que el cliente pueda revisarlo en los reportes',
         );
       }
 


### PR DESCRIPTION
**Descripción general:**  Se modifica la lógica que desencadena una solicitud al endpoint /advisors/{advisorId}/requests/{requestId}/change-status/{statusId}' pra actualizar el estado de la solicitud

**Tareas hechas:**

* Hacer que por el cuerpo de la request se reciba de forma opcional un comentario
* Se debe validar que este comentario sea requerido cuando los estados de la solicitudse quieren cambiar a "aceptado", "aceptado codeudor", "abortado cliente", "abortado akin","incumplimiento akin", "incumplimiento  cliente" y "rechazado"
* Se debe guardar el comentario como un reporte asociado a la solicitud
* Notificar al cliente en el cambio de los estados. En caso de ser un estado que tiene un comentario en reportes(aceptada, rechazada, etc..) se debe informar en el email que revise los comentarios dentro de la plataforma.

Ver la descripción de [este ticket](https://trello.com/c/VQ4RXjqI) en Trello.